### PR TITLE
fix: P&L price caching and nginx backend proxy

### DIFF
--- a/backend/app/routers/prices.py
+++ b/backend/app/routers/prices.py
@@ -28,7 +28,15 @@ def get_price_service():
 def save_prices_to_cache(db: Session, holdings: list, prices: Dict):
     """Save fetched prices to the cache table for instant future loads."""
     now = datetime.now()
+    seen = set()  # Track (symbol, exchange) to avoid duplicate inserts
+    saved_count = 0
+    
     for holding in holdings:
+        key = (holding.symbol, holding.exchange)
+        if key in seen:
+            continue
+        seen.add(key)
+        
         price = prices.get(holding.symbol)
         if price:
             # Upsert: insert or update if exists
@@ -50,10 +58,11 @@ def save_prices_to_cache(db: Session, holdings: list, prices: Dict):
                     updated_at=now
                 )
                 db.add(cache_entry)
+            saved_count += 1
     
     try:
         db.commit()
-        logger.info(f"Saved {len(prices)} prices to cache")
+        logger.info(f"Saved {saved_count} prices to cache")
     except Exception as e:
         logger.error(f"Failed to save prices to cache: {e}")
         db.rollback()
@@ -198,9 +207,17 @@ async def refresh_prices(db: Session = Depends(get_db)) -> Dict:
     symbols = [(h.symbol, h.exchange) for h in holdings]
     prices = PriceService.get_prices_bulk(symbols)
 
-    # Store in price history
+    # Save to CurrentPriceCache for instant loads via /cached endpoint
+    save_prices_to_cache(db, holdings, prices)
+
+    # Store in price history (deduplicate by symbol+exchange to avoid UNIQUE constraint)
     today = date.today()
+    seen = set()
     for holding in holdings:
+        key = (holding.symbol, holding.exchange)
+        if key in seen:
+            continue
+        seen.add(key)
         price = prices.get(holding.symbol)
         if price:
             # Check if we already have today's price

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,7 +13,7 @@ server {
 
     # API proxy to backend
     location /api/ {
-        proxy_pass http://backend:8000/api/;
+        proxy_pass http://portfolio-tracker-backend:8000/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
Fixes the P&L Summary card not showing on the Activity page.

## Changes
1. **nginx.conf**: Fixed proxy to use correct k8s service name (`portfolio-tracker-backend` instead of `backend`)
2. **prices.py**: 
   - Added `save_prices_to_cache()` call to the `/refresh` endpoint
   - Added deduplication by symbol+exchange to avoid UNIQUE constraint errors when the same stock exists in multiple accounts (e.g., XEQT in both TFSA and RRSP)

## Testing
- Verified prices are now correctly cached in the database
- P&L Summary card displays with current price, market value, and profit/loss calculations